### PR TITLE
implemented semester dropdown and dark mode

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -33,7 +33,7 @@
 
   <link rel="stylesheet" type="text/css" href="stylesheet.css">
   <script defer src="full.js"></script>
-  <script defer src="script-compiled.js"></script>
+  <script defer src="script.js"></script>
 </head>
 
 <body>
@@ -47,9 +47,9 @@
     <div id="left-int-div">
       <div id='calendar'></div>
     </div>
-    <div id="export-div"><!-- <span id="prereg-link">Preregister these classes!</span> | --><span id="calendar-link" data-toggle="tooltip" data-placement="top" title="Might be broken! I'm working on it." data-trigger="hover"><!--"Make sure popups are enabled!"--> Export to Google Calendar</span> | <span id="clipboard-link">Text form</span> | <span id="toggle-css">Toggle high-contrast</span> | <span id="clear-all">Clear all</span></div>
+    <div id="export-div"><!-- <span id="prereg-link">Preregister these classes!</span> | --><span id="calendar-link" data-toggle="tooltip" data-placement="top" title="Might be broken! I'm working on it." data-trigger="hover"><!--"Make sure popups are enabled!"--> Export to Google Calendar</span> | <span id="clipboard-link">Text form</span> | <span id="toggle-css">Toggle high-contrast</span> | <span id="toggle-dark-mode">Toggle dark-mode</span> | <span id="clear-all">Clear all</span></div>
     <div id="footer-div">
-      &copy; 2020 <a href="mailto:edwardf@alum.mit.edu">Edward Fan</a>. High-contrast theme by Shannon Peng. <br>Subject descriptions and evaluations are &copy; 2014-2020 Massachusetts Institute of Technology.
+      &copy; 2020 <a href="mailto:edwardf@alum.mit.edu">Edward Fan</a>. High-contrast theme by Shannon Peng. Dark-mode by Mindren Lu. <br>Subject descriptions and evaluations are &copy; 2014-2020 Massachusetts Institute of Technology.
     </div>
   </div>
 
@@ -57,7 +57,21 @@
     <div id="spacer3-div"></div>
     <div id="info-div">
       <img src="img/logo.png" height="40px" vspace="2%" />
-      <p style="margin-bottom: 12px;"><a href="semesters/s20/spring.html"><span style="font-size: 70%">Spring 2020</span></a> | Fall 2020</p>
+      <!-- <p style="margin-bottom: 12px;"><a href="semesters/s20/spring.html"><span style="font-size: 70%">Spring 2020</span></a> | Fall 2020</p> -->
+      <form autocomplete=off>
+        <select name="semesters" id="semesters" onchange="location = this.options[this.selectedIndex].value;">
+          <option value="index.html" selected>Fall 2020</option>
+          <option value="semesters/s20/spring.html">Spring 2020</option>
+          <!-- <option value="semesters/i20/iap.html">IAP 2020</option> -->
+          <option value="semesters/f19/fall.html">Fall 2019</option>
+          <option value="semesters/s19/spring.html">Spring 2019</option>
+          <option value="semesters/i19/iap.html">IAP 2019</option>
+          <option value="semesters/f18/fall.html">Fall 2018</option>
+          <option value="semesters/s18/spring.html">Spring 2018</option>
+          <option value="semesters/i18/iap.html">IAP 2018</option>
+          <option value="semesters/f17/fall.html">Fall 2017</option>
+        </select>
+      </form>
       <!-- <span id="info-line">I'll be at Jane Street's booth at Career Fair- come say hi!</span> -->
     </div>
     <hr>

--- a/www/script.js
+++ b/www/script.js
@@ -1159,10 +1159,13 @@ function set_css(css_state) {
 
 function set_dark_mode(dark_mode) { 
 	$("body, .modal-content").toggleClass("dark-mode-background", dark_mode);
+	$(".modal-content").toggleClass("dark-mode-modal-lists", dark_mode);
 	$(".fc-unthemed .fc-content, .fc-unthemed .fc-divider, .fc-unthemed .fc-list-heading td, .fc-unthemed .fc-list-view, .fc-unthemed .fc-popover, .fc-unthemed .fc-row, .fc-unthemed tbody, .fc-unthemed td, .fc-unthemed th, .fc-unthemed thead, hr").toggleClass("dark-mode-faint", dark_mode);
 	$(".fc-axis, .fc-day-header, #buttons-div, #right-div, #eval-table_wrapper thead, .modal-body").toggleClass("dark-mode-light", dark_mode);
-	$("#buttons-div button, #semesters, input, .dataTables_scrollBody, img[src^='img/cih'], img[src='img/iap.gif'], \
-		img[src='img/repeat.gif'], img[src='img/rest.gif']").toggleClass("dark-mode", dark_mode);
+	$(".dataTables_scrollBody").toggleClass("dark-mode-container", dark_mode);
+	$("img[src^='img/cih'], img[src='img/iap.gif'], img[src='img/repeat.gif'], img[src='img/rest.gif']").toggleClass("dark-mode-invert", dark_mode);
+	$("#buttons-div button, #semesters, input").toggleClass("dark-mode-background dark-mode-light dark-mode-faint", dark_mode);
+	$("html").toggleClass("dark-mode-html", dark_mode);
 }
 
 $(document).ready(function () {

--- a/www/script.js
+++ b/www/script.js
@@ -35,6 +35,7 @@ var activities = [];
 var locked_slots = {};
 var gcal_slots = [];
 var new_css = false;
+var dark_mode = false;
 
 var colors = ["#16A085", "#3E9ED1", "#AE7CB4", "#CA434B", "#E4793C", "#D7AD00", "#27AE60", "#F08E94", "#8FBDD9", "#A2ACB0"];
 var colors_dark = ["#36C0A5", "#5EBEF1", "#CE9CD4", "#EA636B", "#FF995C", "#F7CD20", "#47CE80", "#FFAEB4", "#AFDDF9", "#C2CCD0"];
@@ -408,6 +409,7 @@ function set_option(index) {
 
 	localStorage.setObj('fall20_cur_option', cur_option);
 	set_css(new_css);
+	set_dark_mode(dark_mode);
 }
 
 function conflict_helper(new_sections, old_slots) {
@@ -1155,6 +1157,14 @@ function set_css(css_state) {
 	}
 }
 
+function set_dark_mode(dark_mode) { 
+	$("body, .modal-content").toggleClass("dark-mode-background", dark_mode);
+	$(".fc-unthemed .fc-content, .fc-unthemed .fc-divider, .fc-unthemed .fc-list-heading td, .fc-unthemed .fc-list-view, .fc-unthemed .fc-popover, .fc-unthemed .fc-row, .fc-unthemed tbody, .fc-unthemed td, .fc-unthemed th, .fc-unthemed thead, hr").toggleClass("dark-mode-faint", dark_mode);
+	$(".fc-axis, .fc-day-header, #buttons-div, #right-div, #eval-table_wrapper thead, .modal-body").toggleClass("dark-mode-light", dark_mode);
+	$("#buttons-div button, #semesters, input, .dataTables_scrollBody, img[src^='img/cih'], img[src='img/iap.gif'], \
+		img[src='img/repeat.gif'], img[src='img/rest.gif']").toggleClass("dark-mode", dark_mode);
+}
+
 $(document).ready(function () {
 	Cookies.set('school', 'MIT', { expires: 3650 });
 
@@ -1395,6 +1405,12 @@ $(document).ready(function () {
 		new_css = !new_css
 		set_css(new_css);
 		localStorage.setObj('new_css', new_css);
+	});
+
+	$("#toggle-dark-mode").click(function () {
+		dark_mode = !dark_mode;
+		set_dark_mode(dark_mode)
+		localStorage.setObj('dark_mode', dark_mode);
 	});
 
 	$("#clear-all").click(function () {
@@ -1639,5 +1655,10 @@ $(document).ready(function () {
 	if (localStorage.getObj('new_css')) {
 		new_css = localStorage.getObj('new_css', new_css);
 		set_css(new_css);
+	}
+
+	if (localStorage.getObj('dark_mode')) {
+		dark_mode = localStorage.getObj('dark_mode', dark_mode);
+		set_dark_mode(dark_mode);
 	}
 });

--- a/www/semesters/f17/fall.html
+++ b/www/semesters/f17/fall.html
@@ -56,7 +56,21 @@
     <div id="spacer3-div"></div>
     <div id="info-div">
       <img src="../../img/logo.png" height="40px" vspace="2%" />
-      <p style="margin-bottom: 12px;">Fall 2017 | <a href="/"><span style="font-size: 70%">Current semester</span></a></p>
+      <!-- <p style="margin-bottom: 12px;">Fall 2017 | <a href="/"><span style="font-size: 70%">Current semester</span></a></p> -->
+      <form autocomplete=off>
+          <select name="semesters" id="semesters" onchange="location = this.options[this.selectedIndex].value;">
+            <option value="../../index.html">Fall 2020</option>
+            <option value="../s20/spring.html">Spring 2020</option>
+            <!-- <option value="../i20/iap.html">IAP 2020</option> -->
+            <option value="../f19/fall.html">Fall 2019</option>
+            <option value="../s19/spring.html">Spring 2019</option>
+            <option value="../i19/iap.html">IAP 2019</option>
+            <option value="../f18/fall.html">Fall 2018</option>
+            <option value="../s18/spring.html">Spring 2018</option>
+            <option value="../i18/iap.html">IAP 2018</option>
+            <option value="../f17/fall.html" selected>Fall 2017</option>
+          </select>
+        </form>
       <!-- <span id="info-line">Note: Many classes only run for part of IAP- check the catalog!</span> -->
     </div>
     <hr>

--- a/www/semesters/f18/fall.html
+++ b/www/semesters/f18/fall.html
@@ -56,7 +56,21 @@
     <div id="spacer3-div"></div>
     <div id="info-div">
       <img src="../../img/logo.png" height="40px" vspace="2%" />
-      <p style="margin-bottom: 12px;">Fall 2018 | <a href="/"><span style="font-size: 70%">Current semester</span></a></p>
+      <!-- <p style="margin-bottom: 12px;">Fall 2018 | <a href="/"><span style="font-size: 70%">Current semester</span></a></p> -->
+      <form autocomplete=off>
+          <select name="semesters" id="semesters" onchange="location = this.options[this.selectedIndex].value;">
+            <option value="../../index.html">Fall 2020</option>
+            <option value="../s20/spring.html">Spring 2020</option>
+            <!-- <option value="../i20/iap.html">IAP 2020</option> -->
+            <option value="../f19/fall.html">Fall 2019</option>
+            <option value="../s19/spring.html">Spring 2019</option>
+            <option value="../i19/iap.html">IAP 2019</option>
+            <option value="../f18/fall.html" selected>Fall 2018</option>
+            <option value="../s18/spring.html">Spring 2018</option>
+            <option value="../i18/iap.html">IAP 2018</option>
+            <option value="../f17/fall.html">Fall 2017</option>
+          </select>
+        </form>
     </div>
     <hr>
 

--- a/www/semesters/f19/fall.html
+++ b/www/semesters/f19/fall.html
@@ -57,7 +57,21 @@
     <div id="spacer3-div"></div>
     <div id="info-div">
       <img src="../../img/logo.png" height="40px" vspace="2%" />
-      <p style="margin-bottom: 12px;">Fall 2019 | <a href="../s20/spring.html"><span style="font-size: 70%">Spring 2020</span></a></p>
+      <!-- <p style="margin-bottom: 12px;">Fall 2019 | <a href="../s20/spring.html"><span style="font-size: 70%">Spring 2020</span></a></p> -->
+      <form autocomplete=off>
+          <select name="semesters" id="semesters" onchange="location = this.options[this.selectedIndex].value;">
+            <option value="../../index.html">Fall 2020</option>
+            <option value="../s20/spring.html">Spring 2020</option>
+            <!-- <option value="../i20/iap.html">IAP 2020</option> -->
+            <option value="../f19/fall.html" selected>Fall 2019</option>
+            <option value="../s19/spring.html">Spring 2019</option>
+            <option value="../i19/iap.html">IAP 2019</option>
+            <option value="../f18/fall.html">Fall 2018</option>
+            <option value="../s18/spring.html">Spring 2018</option>
+            <option value="../i18/iap.html">IAP 2018</option>
+            <option value="../f17/fall.html">Fall 2017</option>
+          </select>
+        </form>
     </div>
     <hr>
 

--- a/www/semesters/i18/iap.html
+++ b/www/semesters/i18/iap.html
@@ -56,7 +56,21 @@
     <div id="spacer3-div"></div>
     <div id="info-div">
       <img src="../../img/logo.png" height="40px" vspace="2%" />
-      <p style="margin-bottom: 12px;">IAP 2018 | <a href="../s18/spring.html"><span style="font-size: 70%">Spring 2018</span></a> | <a href="/"><span style="font-size: 70%">Fall 2018</span></a></p>
+      <!-- <p style="margin-bottom: 12px;">IAP 2018 | <a href="../s18/spring.html"><span style="font-size: 70%">Spring 2018</span></a> | <a href="/"><span style="font-size: 70%">Fall 2018</span></a></p> -->
+      <form autocomplete=off>
+          <select name="semesters" id="semesters" onchange="location = this.options[this.selectedIndex].value;">
+            <option value="../../index.html">Fall 2020</option>
+            <option value="../s20/spring.html">Spring 2020</option>
+            <!-- <option value="../i20/iap.html">IAP 2020</option> -->
+            <option value="../f19/fall.html">Fall 2019</option>
+            <option value="../s19/spring.html">Spring 2019</option>
+            <option value="../i19/iap.html">IAP 2019</option>
+            <option value="../f18/fall.html">Fall 2018</option>
+            <option value="../s18/spring.html">Spring 2018</option>
+            <option value="../i18/iap.html" selected>IAP 2018</option>
+            <option value="../f17/fall.html">Fall 2017</option>
+          </select>
+        </form>
       <span id="info-line">Note: Many classes only run for part of IAP- check the catalog!</span>
     </div>
     <hr>

--- a/www/semesters/i19/iap.html
+++ b/www/semesters/i19/iap.html
@@ -56,7 +56,21 @@
     <div id="spacer3-div"></div>
     <div id="info-div">
       <img src="../../img/logo.png" height="40px" vspace="2%" />
-      <p style="margin-bottom: 12px;">IAP 2019 | <a href="../s19/spring.html"><span style="font-size: 70%">Spring 2019</span></a> | <a href="/"><span style="font-size: 70%">Fall 2019</span></a></p>
+      <!-- <p style="margin-bottom: 12px;">IAP 2019 | <a href="../s19/spring.html"><span style="font-size: 70%">Spring 2019</span></a> | <a href="/"><span style="font-size: 70%">Fall 2019</span></a></p> -->
+      <form autocomplete=off>
+          <select name="semesters" id="semesters" onchange="location = this.options[this.selectedIndex].value;">
+            <option value="../../index.html">Fall 2020</option>
+            <option value="../s20/spring.html">Spring 2020</option>
+            <!-- <option value="../i20/iap.html">IAP 2020</option> -->
+            <option value="../f19/fall.html">Fall 2019</option>
+            <option value="../s19/spring.html">Spring 2019</option>
+            <option value="../i19/iap.html" selected>IAP 2019</option>
+            <option value="../f18/fall.html">Fall 2018</option>
+            <option value="../s18/spring.html">Spring 2018</option>
+            <option value="../i18/iap.html">IAP 2018</option>
+            <option value="../f17/fall.html">Fall 2017</option>
+          </select>
+        </form>
       <span id="info-line">Note: Many classes only run for part of IAP- check the catalog!</span>
     </div>
     <hr>

--- a/www/semesters/s18/spring.html
+++ b/www/semesters/s18/spring.html
@@ -56,7 +56,21 @@
     <div id="spacer3-div"></div>
     <div id="info-div">
       <img src="../../img/logo.png" height="40px" vspace="2%" />
-      <p style="margin-bottom: 12px;"><a href="../i18/iap.html"><span style="font-size: 70%">IAP 2018</span></a> | Spring 2018 | <a href="/"><span style="font-size: 70%">Fall 2018</span></a></p>
+      <!-- <p style="margin-bottom: 12px;"><a href="../i18/iap.html"><span style="font-size: 70%">IAP 2018</span></a> | Spring 2018 | <a href="/"><span style="font-size: 70%">Fall 2018</span></a></p> -->
+      <form autocomplete=off>
+          <select name="semesters" id="semesters" onchange="location = this.options[this.selectedIndex].value;">
+            <option value="../../index.html">Fall 2020</option>
+            <option value="../s20/spring.html">Spring 2020</option>
+            <!-- <option value="../i20/iap.html">IAP 2020</option> -->
+            <option value="../f19/fall.html">Fall 2019</option>
+            <option value="../s19/spring.html">Spring 2019</option>
+            <option value="../i19/iap.html">IAP 2019</option>
+            <option value="../f18/fall.html">Fall 2018</option>
+            <option value="../s18/spring.html" selected>Spring 2018</option>
+            <option value="../i18/iap.html">IAP 2018</option>
+            <option value="../f17/fall.html">Fall 2017</option>
+          </select>
+        </form>
       <!-- <span id="info-line">Want to take classes <em>and</em> intern? Check out <a href="http://xterms.mit.edu" target="_blank">x-terms</a>!</span> -->
     </div>
     <hr>

--- a/www/semesters/s19/spring.html
+++ b/www/semesters/s19/spring.html
@@ -56,7 +56,21 @@
     <div id="spacer3-div"></div>
     <div id="info-div">
       <img src="../../img/logo.png" height="40px" vspace="2%" />
-      <p style="margin-bottom: 12px;"><a href="../i19/iap.html"><span style="font-size: 70%">IAP 2019</span></a> | Spring 2019 | <a href="/"><span style="font-size: 70%">Fall 2019</span></a></p>
+      <!-- <p style="margin-bottom: 12px;"><a href="../i19/iap.html"><span style="font-size: 70%">IAP 2019</span></a> | Spring 2019 | <a href="/"><span style="font-size: 70%">Fall 2019</span></a></p> -->
+      <form autocomplete=off>
+          <select name="semesters" id="semesters" onchange="location = this.options[this.selectedIndex].value;">
+            <option value="../../index.html">Fall 2020</option>
+            <option value="../s20/spring.html">Spring 2020</option>
+            <!-- <option value="../i20/iap.html">IAP 2020</option> -->
+            <option value="../f19/fall.html">Fall 2019</option>
+            <option value="../s19/spring.html" selected>Spring 2019</option>
+            <option value="../i19/iap.html">IAP 2019</option>
+            <option value="../f18/fall.html">Fall 2018</option>
+            <option value="../s18/spring.html">Spring 2018</option>
+            <option value="../i18/iap.html">IAP 2018</option>
+            <option value="../f17/fall.html">Fall 2017</option>
+          </select>
+        </form>
       <!-- <span id="info-line"><span id="prereg-link">Pre-register from Firehose!</span></span> -->
     </div>
     <hr>

--- a/www/semesters/s20/spring.html
+++ b/www/semesters/s20/spring.html
@@ -57,7 +57,21 @@
     <div id="spacer3-div"></div>
     <div id="info-div">
       <img src="../../img/logo.png" height="40px" vspace="2%" />
-      <p style="margin-bottom: 12px;">Spring 2020 | <a href="/"><span style="font-size: 70%">Fall 2020</span></a></p>
+      <!-- <p style="margin-bottom: 12px;">Spring 2020 | <a href="/"><span style="font-size: 70%">Fall 2020</span></a></p> -->
+      <form autocomplete=off>
+          <select name="semesters" id="semesters" onchange="location = this.options[this.selectedIndex].value;">
+            <option value="../../index.html">Fall 2020</option>
+            <option value="../s20/spring.html" selected>Spring 2020</option>
+            <!-- <option value="../i20/iap.html">IAP 2020</option> -->
+            <option value="../f19/fall.html">Fall 2019</option>
+            <option value="../s19/spring.html">Spring 2019</option>
+            <option value="../i19/iap.html">IAP 2019</option>
+            <option value="../f18/fall.html">Fall 2018</option>
+            <option value="../s18/spring.html">Spring 2018</option>
+            <option value="../i18/iap.html">IAP 2018</option>
+            <option value="../f17/fall.html">Fall 2017</option>
+          </select>
+        </form>
       <!-- <span id="info-line">I'll be at Jane Street's booth at Career Fair- come say hi!</span> -->
     </div>
     <hr>

--- a/www/stylesheet.css
+++ b/www/stylesheet.css
@@ -68,12 +68,12 @@
     margin: 10 auto 0 auto;
 }
 
-#prereg-link, #calendar-link, #clipboard-link, #toggle-css, #clear-all {
+#export-div span {
     color: #0275d8;
     cursor: pointer;
 }
 
-#prereg-link:hover, #calendar-link:hover, #clipboard-link:hover, #toggle-css:hover, #clear-all:hover {
+#export-div span:hover {
     text-decoration: underline;
 }
 
@@ -217,7 +217,7 @@
 
 .btn-primary, .btn-primary.focus {
     color: #ec5339;
-    background-color: #fff;
+    background-color: transparent;
     border-color: #ec5339;
     background-image: none;
     outline: 0 !important;
@@ -360,6 +360,27 @@
 }
 :-ms-input-placeholder { /* Internet Explorer 10-11 */
     color:    #909090;
+}
+
+.dark-mode {
+    filter: invert(87.45%);
+}
+
+.dark-mode::selection, .dark-mode *::selection { /* fix highlighting issue */
+    background: #ff8800;
+    color: #000000;
+}
+
+.dark-mode-background {
+    background-color: #202020;
+}
+
+.dark-mode-faint {
+    border-color: #303030 !important;
+}
+
+.dark-mode-light {
+    color: #c8c5c3;
 }
 
 /* text boxes */

--- a/www/stylesheet.css
+++ b/www/stylesheet.css
@@ -362,25 +362,63 @@
     color:    #909090;
 }
 
-.dark-mode {
-    filter: invert(87.45%);
+.dataTables_scrollBody {
+    background-color: transparent !important;
 }
 
-.dark-mode::selection, .dark-mode *::selection { /* fix highlighting issue */
-    background: #ff8800;
-    color: #000000;
+.dark-mode-invert {
+    filter: invert(87.45%);
 }
 
 .dark-mode-background {
     background-color: #202020;
 }
 
-.dark-mode-faint {
+.dark-mode-faint, .dark-mode-container td {
     border-color: #303030 !important;
 }
 
-.dark-mode-light {
+.dark-mode-light, .dark-mode-container tr {
     color: #c8c5c3;
+}
+
+.dark-mode-container .odd, .dark-mode-container .even>.sorting_1 {
+    background-color: #282828 !important;
+}
+
+.dark-mode-container .odd>.sorting_1 {
+    background-color: #303030 !important;
+}
+
+.dark-mode-container .even {
+    background-color: #202020 !important;
+}
+
+::-webkit-scrollbar-corner {
+    background-color: rgba(0, 0, 0, 0);
+}
+
+::-webkit-scrollbar, ::-webkit-scrollbar-track {
+    background-color: #F5F5F5;
+    border-radius: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    background-color: #c0c0c0;
+}
+
+.dark-mode-html ::-webkit-scrollbar, .dark-mode-html ::-webkit-scrollbar-track {
+    background-color: #242424;
+}
+
+.dark-mode-html ::-webkit-scrollbar-thumb {
+    background-color: #999999;
+} 
+
+.dark-mode-html .ui-timepicker-list>* {
+    background-color: #202020 !important;
+    color: #c8c5c3 !important;
 }
 
 /* text boxes */


### PR DESCRIPTION
Allows for access of previous semesters using a dropdown menu under the firehose logo.

Also implements a working dark mode for the site. The color scheme mostly preserves what was already being used in light mode. I do note that I have a small issue I wasn't able to resolve with being unable to uninvert the colors of the links in the first column of the table of classes from orange to blue. This currently works only with Fall 2020, as I wasn't sure how to effectively edit the necessary compiled JS files in the older semesters (see below).

I also changed index.html to reference script.js rather than script-compiled.js, as I wasn't sure how to best generate the compiled version; I will let you handle that, if that's alright.

Let me know if everything otherwise looks okay. Thanks!

![image](https://user-images.githubusercontent.com/42189754/89162853-47582580-d53a-11ea-813a-d8be7c1e06e4.png)
